### PR TITLE
Fix a possible typo error

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = dialog
 function dialog (opt) {
   opt = opt || {}
   opt = {
-    'img': {src: opt.icon || ''},
+    '.img': {src: opt.icon || ''},
     '.ok': opt.ok || 'OK',
     '.cancel': opt.cancel || 'Cancel',
     '.url': opt.hostname || window.location.hostname


### PR DESCRIPTION
I think `img` should have a leading period(`.`), as this property is not properly evaluated and as a result the title text always has 40px left margin, even if there is no icon specified.
