### PR TITLE
Dialog box options position updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
     <input tabindex="1">
   </form>
   <div class="divider"></div>
-  <button class="cancel" tabindex="3"></button>
   <button class="ok" tabindex="2"></button>
+  <button class="cancel" tabindex="3"></button>
 </div>

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function render (type, title, defaultValue, cb) {
     input.focus()
     if (defaultValue) input.setSelectionRange(0, defaultValue.length)
   } else {
-    el.querySelector('.ok').focus()
+    el.querySelector('.cancel').focus()
   }
 
   eventListeners('addEventListener')


### PR DESCRIPTION
To prevent mistakes of making changes mistakenly, the '**ok**' button of confirm boxes are usually placed to the **left** and the '**cancel**' to the **right**. ( _Try `prompt` or `confirm` in Chrome_ ) . This update does that.